### PR TITLE
Add EF Core SQLite todo console app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,38 @@
-# Net Framework SQLite
+# Todo Console App (.NET Framework 4.7 + EF Core + SQLite)
+
+This repository contains a simple console-based todo list application that targets **.NET Framework 4.7** and uses **Entity Framework Core** with **SQLite** for data storage.
+
+## Project structure
+
+- `TodoConsoleApp/` – Console application with Entity Framework Core DbContext, models, and services.
+  - `TodoConsoleApp.csproj` – Project file targeting `net47` and referencing EF Core packages.
+  - `Program.cs` – Entry point and user interface loop.
+  - `TodoContext.cs` – EF Core `DbContext` configured for SQLite.
+  - `TodoItem.cs` – Todo entity definition.
+  - `TodoService.cs` – Helper service exposing CRUD operations.
+
+## Requirements
+
+- .NET SDK capable of building .NET Framework 4.7 projects (e.g., Visual Studio 2019 or newer on Windows).
+
+## Getting started
+
+1. Restore NuGet packages:
+   ```bash
+   dotnet restore TodoConsoleApp/TodoConsoleApp.csproj
+   ```
+2. Build the console app:
+   ```bash
+   dotnet build TodoConsoleApp/TodoConsoleApp.csproj
+   ```
+3. Run the application:
+   ```bash
+   dotnet run --project TodoConsoleApp/TodoConsoleApp.csproj
+   ```
+
+When run for the first time the application creates a `todo.db` SQLite database in the output directory. Use the menu to add tasks, mark them as completed, list existing tasks, or delete entries.
+
+## Notes
+
+- Entity Framework Core automatically ensures the SQLite database file exists via `Database.EnsureCreated()`.
+- Tasks are timestamped using UTC and displayed in your local time zone in the console.

--- a/TodoConsoleApp/Program.cs
+++ b/TodoConsoleApp/Program.cs
@@ -1,0 +1,150 @@
+using System;
+using System.Globalization;
+
+namespace TodoConsoleApp
+{
+    internal static class Program
+    {
+        private static void Main()
+        {
+            using (var context = new TodoContext())
+            {
+                context.Database.EnsureCreated();
+            }
+
+            var service = new TodoService(() => new TodoContext());
+            var app = new TodoConsoleApp(service);
+            app.Run();
+        }
+    }
+
+    internal sealed class TodoConsoleApp
+    {
+        private readonly TodoService _service;
+
+        public TodoConsoleApp(TodoService service)
+        {
+            _service = service ?? throw new ArgumentNullException(nameof(service));
+        }
+
+        public void Run()
+        {
+            var shouldExit = false;
+            while (!shouldExit)
+            {
+                DisplayMenu();
+                var input = Console.ReadLine();
+                Console.WriteLine();
+
+                switch (input)
+                {
+                    case "1":
+                        ListTodos();
+                        break;
+                    case "2":
+                        AddTodo();
+                        break;
+                    case "3":
+                        CompleteTodo();
+                        break;
+                    case "4":
+                        DeleteTodo();
+                        break;
+                    case "5":
+                        shouldExit = true;
+                        break;
+                    default:
+                        Console.WriteLine("Unrecognized option. Please choose between 1 and 5.");
+                        break;
+                }
+
+                if (!shouldExit)
+                {
+                    Console.WriteLine();
+                    Console.WriteLine("Press ENTER to continue...");
+                    Console.ReadLine();
+                }
+            }
+        }
+
+        private static void DisplayMenu()
+        {
+            Console.Clear();
+            Console.WriteLine("==============================");
+            Console.WriteLine("        TODO LIST APP         ");
+            Console.WriteLine("==============================");
+            Console.WriteLine("1. View tasks");
+            Console.WriteLine("2. Add a task");
+            Console.WriteLine("3. Mark task as completed");
+            Console.WriteLine("4. Delete a task");
+            Console.WriteLine("5. Exit");
+            Console.Write("Select an option: ");
+        }
+
+        private void ListTodos()
+        {
+            var todos = _service.GetTodos();
+
+            if (todos.Count == 0)
+            {
+                Console.WriteLine("No tasks found. Add your first task!");
+                return;
+            }
+
+            Console.WriteLine("Current tasks:");
+            Console.WriteLine();
+
+            foreach (var todo in todos)
+            {
+                var status = todo.IsCompleted ? "[x]" : "[ ]";
+                var created = todo.CreatedAt.ToLocalTime().ToString("g", CultureInfo.CurrentCulture);
+                Console.WriteLine(string.Format(CultureInfo.CurrentCulture, "{0} {1}. {2} (Created {3})", status, todo.Id, todo.Title, created));
+            }
+        }
+
+        private void AddTodo()
+        {
+            Console.Write("Enter a task description: ");
+            var title = Console.ReadLine();
+
+            if (string.IsNullOrWhiteSpace(title))
+            {
+                Console.WriteLine("Task description cannot be empty.");
+                return;
+            }
+
+            _service.AddTodo(title.Trim());
+            Console.WriteLine("Task added successfully.");
+        }
+
+        private void CompleteTodo()
+        {
+            Console.Write("Enter the task id to mark as completed: ");
+            var input = Console.ReadLine();
+
+            if (!int.TryParse(input, NumberStyles.Integer, CultureInfo.InvariantCulture, out var id))
+            {
+                Console.WriteLine("Invalid id. Please enter a numeric value.");
+                return;
+            }
+
+            var result = _service.CompleteTodo(id);
+            Console.WriteLine(result ? "Task marked as completed." : "Task not found.");
+        }
+
+        private void DeleteTodo()
+        {
+            Console.Write("Enter the task id to delete: ");
+            var input = Console.ReadLine();
+
+            if (!int.TryParse(input, NumberStyles.Integer, CultureInfo.InvariantCulture, out var id))
+            {
+                Console.WriteLine("Invalid id. Please enter a numeric value.");
+                return;
+            }
+
+            var result = _service.DeleteTodo(id);
+            Console.WriteLine(result ? "Task deleted." : "Task not found.");
+        }
+    }
+}

--- a/TodoConsoleApp/TodoConsoleApp.csproj
+++ b/TodoConsoleApp/TodoConsoleApp.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net47</TargetFramework>
+    <LangVersion>7.3</LangVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.1.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.1.4" />
+  </ItemGroup>
+</Project>

--- a/TodoConsoleApp/TodoContext.cs
+++ b/TodoConsoleApp/TodoContext.cs
@@ -1,0 +1,49 @@
+using System;
+using System.IO;
+using Microsoft.EntityFrameworkCore;
+
+namespace TodoConsoleApp
+{
+    public sealed class TodoContext : DbContext
+    {
+        private readonly string _databasePath;
+
+        public TodoContext()
+            : this(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "todo.db"))
+        {
+        }
+
+        public TodoContext(string databasePath)
+        {
+            if (string.IsNullOrWhiteSpace(databasePath))
+            {
+                throw new ArgumentException("Value cannot be null or whitespace.", nameof(databasePath));
+            }
+
+            _databasePath = databasePath;
+        }
+
+        public DbSet<TodoItem> TodoItems { get; set; }
+
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+        {
+            if (!optionsBuilder.IsConfigured)
+            {
+                optionsBuilder.UseSqlite(string.Format("Data Source={0}", _databasePath));
+            }
+        }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<TodoItem>(entity =>
+            {
+                entity.HasKey(e => e.Id);
+                entity.Property(e => e.Title)
+                    .IsRequired()
+                    .HasMaxLength(200);
+                entity.Property(e => e.CreatedAt)
+                    .IsRequired();
+            });
+        }
+    }
+}

--- a/TodoConsoleApp/TodoItem.cs
+++ b/TodoConsoleApp/TodoItem.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace TodoConsoleApp
+{
+    public class TodoItem
+    {
+        public int Id { get; set; }
+
+        public string Title { get; set; }
+
+        public bool IsCompleted { get; set; }
+
+        public DateTime CreatedAt { get; set; }
+    }
+}

--- a/TodoConsoleApp/TodoService.cs
+++ b/TodoConsoleApp/TodoService.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace TodoConsoleApp
+{
+    public sealed class TodoService
+    {
+        private readonly Func<TodoContext> _contextFactory;
+
+        public TodoService(Func<TodoContext> contextFactory)
+        {
+            _contextFactory = contextFactory ?? throw new ArgumentNullException(nameof(contextFactory));
+        }
+
+        public IList<TodoItem> GetTodos()
+        {
+            using (var context = _contextFactory())
+            {
+                return context.TodoItems
+                    .OrderBy(t => t.IsCompleted)
+                    .ThenBy(t => t.CreatedAt)
+                    .ToList();
+            }
+        }
+
+        public void AddTodo(string title)
+        {
+            if (string.IsNullOrWhiteSpace(title))
+            {
+                throw new ArgumentException("Value cannot be null or whitespace.", nameof(title));
+            }
+
+            using (var context = _contextFactory())
+            {
+                var todo = new TodoItem
+                {
+                    Title = title.Trim(),
+                    CreatedAt = DateTime.UtcNow,
+                    IsCompleted = false
+                };
+
+                context.TodoItems.Add(todo);
+                context.SaveChanges();
+            }
+        }
+
+        public bool CompleteTodo(int id)
+        {
+            using (var context = _contextFactory())
+            {
+                var todo = context.TodoItems.FirstOrDefault(t => t.Id == id);
+                if (todo == null)
+                {
+                    return false;
+                }
+
+                if (!todo.IsCompleted)
+                {
+                    todo.IsCompleted = true;
+                    context.SaveChanges();
+                }
+
+                return true;
+            }
+        }
+
+        public bool DeleteTodo(int id)
+        {
+            using (var context = _contextFactory())
+            {
+                var todo = context.TodoItems.FirstOrDefault(t => t.Id == id);
+                if (todo == null)
+                {
+                    return false;
+                }
+
+                context.TodoItems.Remove(todo);
+                context.SaveChanges();
+                return true;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a .NET Framework 4.7 console todo application backed by EF Core and SQLite
- implement DbContext, entity, and service classes to manage tasks
- document build and run instructions in the README

## Testing
- not run (dotnet CLI is unavailable in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68ce5e28f4f48323b136d7cff5298012